### PR TITLE
add Buffer.js to node-globals-polyfill

### DIFF
--- a/node-globals-polyfill/package.json
+++ b/node-globals-polyfill/package.json
@@ -16,6 +16,7 @@
         "dist",
         "src",
         "esm",
+        "Buffer.js",
         "process.js"
     ],
     "keywords": [],


### PR DESCRIPTION
This PR ensures that Buffer.js is included in the published package.