### PR TITLE
Use base64fromByteArray instead of fromByteArray

### DIFF
--- a/node-globals-polyfill/Buffer.js
+++ b/node-globals-polyfill/Buffer.js
@@ -1069,9 +1069,9 @@ Buffer.prototype.toJSON = function toJSON() {
 
 function base64Slice(buf, start, end) {
     if (start === 0 && end === buf.length) {
-        return fromByteArray(buf)
+        return base64fromByteArray(buf)
     } else {
-        return fromByteArray(buf.slice(start, end))
+        return base64fromByteArray(buf.slice(start, end))
     }
 }
 


### PR DESCRIPTION
Using the `node-globals-polyfill > buffer` polyfill will result in "`fromByteArray` is not defined."

`base64fromByteArray` looks unused so i think this is the correct change.