### PR TITLE
EsmExternals: Fix default export for libraries such as 'styled-components'

### DIFF
--- a/esm-externals/src/index.ts
+++ b/esm-externals/src/index.ts
@@ -21,7 +21,11 @@ export function EsmExternalsPlugin({ externals }: { externals: string[] }) {
             })
             build.onLoad({ filter: /.*/, namespace: NAMESPACE }, (args) => {
                 return {
-                    contents: `export * as default from ${JSON.stringify(args.path)}; export * from ${JSON.stringify(args.path)};`,
+                    contents: `import * as defaultImport from ${JSON.stringify(
+                        args.path,
+                    )}; export * from ${JSON.stringify(
+                        args.path,
+                    )}; export default ('default' in defaultImport ? defaultImport.default : defaultImport);`,
                 }
             })
         },


### PR DESCRIPTION
The ESMExternals library works for libraries such as React and ReactDom, however it fails for StyledComponents because the default export is located inside as `importPath.default`

This PR aims to fix that issue while maintaining compatibility with all existing use cases. 