### PR TITLE
feat: Allow customized filter to be passed from external source

### DIFF
--- a/esm-externals/README.md
+++ b/esm-externals/README.md
@@ -17,10 +17,10 @@ If you would like to customize the filter for externals, you can pass a RegExp o
 import EsmExternals from '@esbuild-plugins/esm-externals'
 import { build } from 'esbuild'
 
-const filter = new RegExp("^(" + ["react", "react-dom"].join("|") + ")$")
+const externalRegExp = new RegExp("^(" + ["react", "react-dom"].join("|") + ")$")
 // this will make all react and react-dom packages externals, but not react/abc or react-dom/abc
 
 build({
-    plugins: [EsmExternals({ externals: ['react', 'react-dom'], filter })],
+    plugins: [EsmExternals({ externals: externalRegExp })],
 })
 ```

--- a/esm-externals/README.md
+++ b/esm-externals/README.md
@@ -9,3 +9,18 @@ build({
     plugins: [EsmExternals({ externals: ['react', 'react-dom'] })],
 })
 ```
+
+If you would like to customize the filter for externals, you can pass a RegExp or a string to the externals option.
+
+```ts
+
+import EsmExternals from '@esbuild-plugins/esm-externals'
+import { build } from 'esbuild'
+
+const filter = new RegExp("^(" + ["react", "react-dom"].join("|") + ")$")
+// this will make all react and react-dom packages externals, but not react/abc or react-dom/abc
+
+build({
+    plugins: [EsmExternals({ externals: ['react', 'react-dom'], filter })],
+})
+```

--- a/esm-externals/src/index.ts
+++ b/esm-externals/src/index.ts
@@ -2,11 +2,12 @@ import escapeStringRegexp from 'escape-string-regexp'
 const NAME = 'esm-externals'
 const NAMESPACE = NAME
 
-export function EsmExternalsPlugin({ externals, filter: customFilter  }: { externals: string[], filter?: RegExp | string }) {
+export function EsmExternalsPlugin({ externals }: { externals: string[] | RegExp  }) {
     return {
         name: NAME,
         setup(build) {
-            const filter = typeof customFilter != "undefined" ? customFilter : makeFilter(externals)
+            const filter = Array.isArray(externals) ? makeFilter(externals ) : externals;
+
             build.onResolve({ filter: /.*/, namespace: NAMESPACE }, (args) => {
                 return {
                     path: args.path,

--- a/esm-externals/src/index.ts
+++ b/esm-externals/src/index.ts
@@ -2,11 +2,11 @@ import escapeStringRegexp from 'escape-string-regexp'
 const NAME = 'esm-externals'
 const NAMESPACE = NAME
 
-export function EsmExternalsPlugin({ externals }: { externals: string[] }) {
+export function EsmExternalsPlugin({ externals, filter: customFilter  }: { externals: string[], filter?: RegExp | string }) {
     return {
         name: NAME,
         setup(build) {
-            const filter = makeFilter(externals)
+            const filter = typeof customFilter != "undefined" ? customFilter : makeFilter(externals)
             build.onResolve({ filter: /.*/, namespace: NAMESPACE }, (args) => {
                 return {
                     path: args.path,

--- a/esm-externals/src/index.ts
+++ b/esm-externals/src/index.ts
@@ -6,7 +6,7 @@ export function EsmExternalsPlugin({ externals }: { externals: string[] | RegExp
     return {
         name: NAME,
         setup(build) {
-            const filter = Array.isArray(externals) ? makeFilter(externals ) : externals;
+            const filter = Array.isArray(externals) ? makeFilter(externals) : externals;
 
             build.onResolve({ filter: /.*/, namespace: NAMESPACE }, (args) => {
                 return {


### PR DESCRIPTION
In my use case, I am utilizing esbuild in development mode and would like to externalize for the `react` and `react-dom` packages. However, I do not want to externalize the nested packages like `react/jsx-runtime` and `react/jsx-dev-runtime.`
```
plugins: [EsmExternals({ externals: ['react', 'react-dom'] })],
```

Currently, the `makeFilter` function defaults to a positive match for all cases, including `react/jsx-runtime` and `react/jsx-dev-runtime`. We have a corresponding test case available [here](https://github.com/remorses/esbuild-plugins/blob/d9f6601a24dc4e0470046eda8c772e6523c52b96/esm-externals/src/index.test.ts#L68-L83).

To address this, I have introduced the ability to pass externals as regrex and customize by myself instead, allowing for customization.
```
const externalRegExp = new RegExp("^(" + ["react", "react-dom"].join("|") + ")$")
// this will make all react and react-dom packages externals, but not react/abc or react-dom/abc

build({
    plugins: [EsmExternals({ externals: externalRegExp })],
})
```
This pull request aims to implement this enhancement and improve the flexibility of the `EsmExternalsPlugin`.

Thank you for your consideration.